### PR TITLE
fix(types): supports exports fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "types": "./src/jdataview.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/jdataview.js"
+      "import": "./dist/jdataview.js",
+      "types": "./src/jdataview.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
We'll going to use node.js's module resolution via `exports/imports`, which'll require types exports as well to resolve type definition correctly.